### PR TITLE
Update OpenFaaS function API version to v1

### DIFF
--- a/functions/templates/certinfo.yaml
+++ b/functions/templates/certinfo.yaml
@@ -1,4 +1,4 @@
-apiVersion: openfaas.com/v1alpha2
+apiVersion: openfaas.com/v1
 kind: Function
 metadata:
   name: certinfo

--- a/functions/templates/podinfo.yaml
+++ b/functions/templates/podinfo.yaml
@@ -1,4 +1,4 @@
-apiVersion: openfaas.com/v1alpha2
+apiVersion: openfaas.com/v1
 kind: Function
 metadata:
   name: podinfo


### PR DESCRIPTION
Implemented on [a project I'm working on](https://github.com/foundry4/appeal-planning-decision/pull/290) and found the `apiVersion` is now different